### PR TITLE
Update url match rules

### DIFF
--- a/wos-download-bot.js
+++ b/wos-download-bot.js
@@ -4,7 +4,6 @@
 // @version      1.4.1
 // @description  wos核心论文集下载机器人
 // @author       AngelLiang
-// @match        https://www.webofscience.com/wos/woscc/summary/*/relevance/*
 // @include      https://*.webofscience.com/wos/woscc/summary/*/relevance/*
 // @include      https://*.clarivate.cn/wos/woscc/summary/*/relevance/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=webofscience.com

--- a/wos-download-bot.js
+++ b/wos-download-bot.js
@@ -4,6 +4,7 @@
 // @version      1.4.1
 // @description  wos核心论文集下载机器人
 // @author       AngelLiang
+// @match        https://www.webofscience.com/wos/woscc/summary/*/relevance/*
 // @include      https://*.webofscience.com/wos/woscc/summary/*/relevance/*
 // @include      https://*.clarivate.cn/wos/woscc/summary/*/relevance/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=webofscience.com

--- a/wos-download-bot.js
+++ b/wos-download-bot.js
@@ -4,7 +4,8 @@
 // @version      1.4.1
 // @description  wos核心论文集下载机器人
 // @author       AngelLiang
-// @match        https://www.webofscience.com/wos/woscc/summary/*/relevance/*
+// @include      https://*.webofscience.com/wos/woscc/summary/*/relevance/*
+// @include      https://*.clarivate.cn/wos/woscc/summary/*/relevance/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=webofscience.com
 // @require      https://cdn.staticfile.org/jquery/3.4.1/jquery.min.js
 // @require      https://cdn.bootcss.com/jquery-cookie/1.4.1/jquery.cookie.js


### PR DESCRIPTION
https://chatgpt.com/share/205ca579-634b-46f1-bfe0-8524170dc9eb

`@include` is better than `@match`, at least for nowadays.